### PR TITLE
Added private server detection.

### DIFF
--- a/whereisdi.lua
+++ b/whereisdi.lua
@@ -67,6 +67,11 @@ end
 
 function login()
     local server_id = windower.ffxi.get_info().server
+    if type(res.servers[server_id]) ~= 'table' or not res.servers[server_id].name then
+        print('WhereisDI: private servers are not supported. Unloading.')
+        windower.send_command('lua unload whereisdi')        
+        return
+    end
     api.login(windower.ffxi.get_player().name, server_id, res.servers[server_id].name)
 end
 


### PR DESCRIPTION
I sometimes use my retail client to connect to private servers, and whereisdi errors out when it is the case. This snippet of code prevents the error and unload the addon when the server is not recognized.